### PR TITLE
upgrade bevy to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ url             = { version = "2.4" }
 
 axum        = { version = "0.6", optional = true }
 axum-server = { version = "0.5", optional = true }
-bevy_ecs    = { version = "0.11", optional = true }
+bevy_ecs    = { version = "0.12", optional = true }
 tokio       = { version = "1.29", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
There is a test that fails the RateLimit one but I believe that failed even before this PR. Otherwise I believe everything works.